### PR TITLE
fixed bug where an error was thrown if a time was deleted

### DIFF
--- a/src/components/TimeCardPage/CellTypes/TimeEntry.tsx
+++ b/src/components/TimeCardPage/CellTypes/TimeEntry.tsx
@@ -12,8 +12,16 @@ export function TimeEntry(props: TimeEntryProps) {
   const [minutes, setMinutes] = useState(undefined);
 
   const onChange = (time) => {
-    const [hours, parsedMinutes] = time.split(":");
-    const calculatedTime = Number(hours) * 60 + Number(parsedMinutes);
+    let calculatedTime;
+    // TODO: account for possible time deletions when updating DB and whatnot
+    if (time === null) {
+      const currentHours = null;
+      calculatedTime = undefined;
+    } else {
+      const [currentHours, parsedMinutes] = time.split(":");
+      calculatedTime = Number(currentHours) * 60 + Number(parsedMinutes);
+    }
+
     setMinutes(calculatedTime);
 
     //Triggering parent class to update its references here as well

--- a/src/components/TimeCardPage/CellTypes/TimeEntry.tsx
+++ b/src/components/TimeCardPage/CellTypes/TimeEntry.tsx
@@ -15,7 +15,6 @@ export function TimeEntry(props: TimeEntryProps) {
     let calculatedTime;
     // TODO: account for possible time deletions when updating DB and whatnot
     if (time === null) {
-      const currentHours = null;
       calculatedTime = undefined;
     } else {
       const [currentHours, parsedMinutes] = time.split(":");


### PR DESCRIPTION
ℹ️ Issue
Fix for a timesheet bug where an error was thrown if an entry was deleted
![image](https://github.com/Code-4-Community/breaktime-frontend/assets/52679352/08fbf645-7f0d-4b0c-a1f0-f756ab3ba584)


📝 Description
Briefly list the changes made to the code:

Accounted for the case that time can be null

✔️ Testing
What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.
![image](https://github.com/Code-4-Community/breaktime-frontend/assets/52679352/35d8e5ae-aecd-4f82-a77f-0e2cf37e29f4)

Provide screenshots of any new components, styling changes, or pages.

🏕️ (Optional) Future Work / Notes
Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
